### PR TITLE
pkg: Use d64 for binary encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var Buffer = require('buffer').Buffer
 var number = require('./codec/number.js');
 var object = require('./codec/object.js');
+var d64 = require('d64')
 
 var flip = exports.flip = function (n) {
   var s = n.toString()
@@ -63,11 +64,11 @@ exports.boolean = {
 
 exports.binary = {
   encode: function (b) {
-    return 'I'+b.toString('base64')
+    return 'I'+ d64.encode(b)
   },
   decode: function (s) {
     if ('I' === s[0]) {
-      return Buffer.from(s.substring(1), 'base64')
+      return d64.decode(s.substring(1))
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "type": "git",
     "url": "git://github.com/Raynos/charwise-compact.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "d64": "1.0.0"
+  },
   "devDependencies": {
     "bytewise": "^1.1.0",
     "check-ecmascript-version-compatibility": "^0.1.1",


### PR DESCRIPTION
Apparently Base64 does not preserve sorting but d64 does.

That's great!